### PR TITLE
Add rotation lock state

### DIFF
--- a/src/main/java/frc/robot/commands/RotationLockState.java
+++ b/src/main/java/frc/robot/commands/RotationLockState.java
@@ -1,0 +1,41 @@
+package frc.robot.commands;
+
+import java.util.function.DoubleSupplier;
+
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Rotation2d;
+import frc.robot.subsystems.Drivetrain;
+import frc.team4272.globals.State;
+
+import static frc.robot.constants.AutoConstants.PathUtils.THETA_CONTROLLER;
+
+public class RotationLockState extends State<Drivetrain> {
+    private DoubleSupplier xSpeed;
+    private DoubleSupplier ySpeed;
+    private PIDController thetaController;
+
+    public RotationLockState(Drivetrain drivetrain, DoubleSupplier xSpeed, DoubleSupplier ySpeed, Rotation2d desiredAngle, PIDController thetaController) {
+        super(drivetrain);
+
+        this.xSpeed = xSpeed;
+        this.ySpeed = ySpeed;
+        this.thetaController = thetaController;
+        this.thetaController.enableContinuousInput(-Math.PI, Math.PI);
+        this.thetaController.setSetpoint(desiredAngle.getRadians());
+    }
+
+    public RotationLockState(Drivetrain drivetrain, DoubleSupplier xSpeed, DoubleSupplier ySpeed, Rotation2d desiredAngle) {
+        this(drivetrain, xSpeed, ySpeed, desiredAngle, THETA_CONTROLLER);
+    }
+
+    @Override
+    public void execute() {
+        double thetaSpeed = thetaController.calculate(requiredSubsystem.getRobotPose().getRotation().getRadians());
+        requiredSubsystem.drive(xSpeed.getAsDouble(), ySpeed.getAsDouble(), thetaSpeed);
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        requiredSubsystem.drive(0.0, 0.0, 0.0);
+    }
+}

--- a/src/main/java/frc/robot/commands/RotationLockState.java
+++ b/src/main/java/frc/robot/commands/RotationLockState.java
@@ -8,6 +8,7 @@ import frc.robot.subsystems.Drivetrain;
 import frc.team4272.globals.State;
 
 import static frc.robot.constants.AutoConstants.PathUtils.THETA_CONTROLLER;
+import static frc.robot.constants.RobotConstants.DrivetrainConstants.*;
 
 public class RotationLockState extends State<Drivetrain> {
     private DoubleSupplier xSpeed;
@@ -30,8 +31,8 @@ public class RotationLockState extends State<Drivetrain> {
 
     @Override
     public void execute() {
-        double thetaSpeed = thetaController.calculate(requiredSubsystem.getRobotPose().getRotation().getRadians());
-        requiredSubsystem.drive(xSpeed.getAsDouble(), ySpeed.getAsDouble(), thetaSpeed);
+        double thetaSpeed = -thetaController.calculate(requiredSubsystem.getRobotPose().getRotation().getRadians());
+        requiredSubsystem.drive(ySpeed.getAsDouble() * MAX_TRANS_SPEED, -xSpeed.getAsDouble() * MAX_TRANS_SPEED, thetaSpeed * MAX_ROT_SPEED);
     }
 
     @Override


### PR DESCRIPTION
Add a state where the drivers cannot control the rotation of the robot, only drive it around the field.