### PR TITLE
Elevator homing

### DIFF
--- a/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
@@ -6,6 +6,8 @@ package frc.robot.subsystems.arm;
 
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMax.ControlType;
+import com.revrobotics.SparkMaxLimitSwitch.Type;
+
 import edu.wpi.first.math.controller.ArmFeedforward;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -62,6 +64,8 @@ public class ArmSubsystem extends SubsystemBase {
     private PIDController armController = new PIDController(ROTARY_ARM_PID_P, ROTARY_ARM_PID_I, ROTARY_ARM_PID_D);
 
     private SetpointContainer setpoint =  new SetpointContainer();
+
+    private boolean zeroed = false;
 
     /** Creates a new ArmSubsystem. */
     public ArmSubsystem() {
@@ -173,6 +177,13 @@ public class ArmSubsystem extends SubsystemBase {
             setArmMotor(setpoint.getArmAngle());
         }
         
+        if(!zeroed) {
+            if(elevatorLeftFollower.getForwardLimitSwitch(Type.kNormallyOpen).isPressed()) {
+                elevatorRightLeader.getEncoder().setPosition(0.0);
+                zeroed = true;
+            }
+        }
+
         if(DriverStation.isDisabled()) return;
         double armOutput = 0;
         armOutput = -armController.calculate(armEncoder.getPosition());

--- a/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
@@ -5,6 +5,7 @@
 package frc.robot.subsystems.arm;
 
 import com.revrobotics.CANSparkMax;
+import com.revrobotics.SparkMaxLimitSwitch;
 import com.revrobotics.CANSparkMax.ControlType;
 import com.revrobotics.SparkMaxLimitSwitch.Type;
 
@@ -66,6 +67,7 @@ public class ArmSubsystem extends SubsystemBase {
     private SetpointContainer setpoint =  new SetpointContainer();
 
     private boolean zeroed = false;
+    private SparkMaxLimitSwitch limit;
 
     /** Creates a new ArmSubsystem. */
     public ArmSubsystem() {
@@ -92,6 +94,10 @@ public class ArmSubsystem extends SubsystemBase {
             .build();
 
         armEncoder = new MAVCoder(armMotor, ROTARY_ARM_OFFSET);
+
+        limit = elevatorRightLeader.getReverseLimitSwitch(Type.kNormallyOpen);
+        limit.enableLimitSwitch(true);
+
 
         armController.setIntegratorRange(-0.01, 0.01);
     }
@@ -178,7 +184,7 @@ public class ArmSubsystem extends SubsystemBase {
         }
         
         if(!zeroed) {
-            if(elevatorLeftFollower.getForwardLimitSwitch(Type.kNormallyOpen).isPressed()) {
+            if(limit.isPressed()) {
                 elevatorRightLeader.getEncoder().setPosition(0.0);
                 zeroed = true;
             }


### PR DESCRIPTION
Added homing the elevator in the event we forget to do something, and the elevator encoder isn't set correctly.
This makes sure that the first time the limit switch is tripped, the elevator encoder gets zeroed.